### PR TITLE
Bundle Javascript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ dist/
 *.egg-info/
 node_modules
 .venv
+
+/deno_vm/vm-server/bundle.js

--- a/deno_vm/__init__.py
+++ b/deno_vm/__init__.py
@@ -11,7 +11,7 @@ from os import path, environ
 from .__pkginfo__ import __version__
 
 DENO_EXECUTABLE = "deno"
-VM_SERVER = path.join(path.dirname(__file__), "vm-server/index.js")
+VM_SERVER = path.join(path.dirname(__file__), "vm-server/bundle.js")
 
 def eval(code, **options):
     """A shortcut to eval JavaScript.

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,9 +27,7 @@ zip_safe = False
 packages = find:
 
 [options.package_data]
-deno_vm =
-	vm-server/*.js
-	vm-server/*.json
+deno_vm = vm-server/bundle.js
 
 ; [bdist_wheel]
 ; universal = False

--- a/setup.py
+++ b/setup.py
@@ -1,2 +1,17 @@
-from setuptools import setup
-setup()
+import shutil
+import subprocess
+from setuptools import Command, setup
+from setuptools.command.sdist import sdist
+
+def build_js_bundle():
+    subprocess.check_call([shutil.which("deno"), "bundle", "deno_vm/vm-server/index.js", "deno_vm/vm-server/bundle.js"])
+
+class BuildJSBundle(Command):
+    def initialize_options(self): pass
+    def finalize_options(self): pass
+    def run(self): build_js_bundle()
+
+class Build(sdist):
+    sub_commands = [("build_js_bundle", None), *sdist.sub_commands]
+
+setup(cmdclass={"sdist": Build, "build_js_bundle": BuildJSBundle})

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,8 @@ def build_js_bundle():
     subprocess.check_call([shutil.which("deno"), "bundle", "deno_vm/vm-server/index.js", "deno_vm/vm-server/bundle.js"])
 
 class BuildJSBundle(Command):
+    description = "build the javascript bundle"
+    user_options = []
     def initialize_options(self): pass
     def finalize_options(self): pass
     def run(self): build_js_bundle()


### PR DESCRIPTION
A step towards solving #12.

- [ ] Store generated bundle directly in the sdist directory, not in the source tree.
- [ ] A cleaner way to run the bundle (perhaps when generating the bundle directory in the sdist directory, call it `index.js`).
- [ ] Maybe another approach, as there is a warning - use alternative tool, or resort to caching dependencies instead.
   ```
   ⚠️ Warning: `deno bundle` is deprecated and will be removed in Deno 2.0.
   Use an alternative bundler like "deno_emit", "esbuild" or "rollup" instead.
  ```